### PR TITLE
Postpone connection until first usage by default

### DIFF
--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -40,7 +40,7 @@ describe 'Client - Authorization' do
     @server_control.start_server
     nats = NATS::IO::Client.new
     expect do
-      nats.connect(:servers => [TEST_AUTH_SERVER], :reconnect => false)
+      nats.connect!(:servers => [TEST_AUTH_SERVER], :reconnect => false)
       nats.flush
     end.to_not raise_error
     nats.close
@@ -51,31 +51,31 @@ describe 'Client - Authorization' do
     @server_control.start_server
     nats = NATS::IO::Client.new
     expect do
-      nats.connect(:servers => [TEST_TOKEN_AUTH_SERVER], :reconnect => false)
+      nats.connect!(:servers => [TEST_TOKEN_AUTH_SERVER], :reconnect => false)
       nats.flush
     end.to_not raise_error
     nats.close
 
     expect do
-      nc = NATS.connect(TEST_TOKEN_AUTH_SERVER, reconnect: false)
+      nc = NATS.connect!(TEST_TOKEN_AUTH_SERVER, reconnect: false)
       nc.flush
       nc.close
     end.to_not raise_error
 
     expect do
-      nc = NATS.connect(TEST_AUTH_SERVER_NO_CRED, reconnect: false)
+      nc = NATS.connect!(TEST_AUTH_SERVER_NO_CRED, reconnect: false)
       nc.flush
       nc.close
     end.to raise_error(NATS::IO::AuthError)
 
     expect do
-      nc = NATS.connect(TEST_AUTH_SERVER_NO_CRED, reconnect: false, auth_token: 'secret')
+      nc = NATS.connect!(TEST_AUTH_SERVER_NO_CRED, reconnect: false, auth_token: 'secret')
       nc.flush
       nc.close
     end.to_not raise_error
 
     expect do
-      nc = NATS.connect(TEST_WRONG_TOKEN_AUTH_SERVER, reconnect: false, auth_token: 'secret')
+      nc = NATS.connect!(TEST_WRONG_TOKEN_AUTH_SERVER, reconnect: false, auth_token: 'secret')
       nc.flush
       nc.close
     end.to_not raise_error
@@ -94,7 +94,7 @@ describe 'Client - Authorization' do
       nats.on_error do |e|
         errors << e
       end
-      nats.connect({
+      nats.connect!({
         servers: [TEST_AUTH_SERVER_NO_CRED],
         reconnect: false
       })

--- a/spec/client_cluster_reconnect_spec.rb
+++ b/spec/client_cluster_reconnect_spec.rb
@@ -100,7 +100,7 @@ describe 'Client - Cluster reconnect' do
       mon = Monitor.new
       reconnected = mon.new_cond
 
-      nats = NATS.connect(:servers => [@s1.uri, @s2.uri], :dont_randomize_servers => true)
+      nats = NATS.connect!(:servers => [@s1.uri, @s2.uri], :dont_randomize_servers => true)
 
       disconnects = 0
       nats.on_disconnect do
@@ -152,7 +152,7 @@ describe 'Client - Cluster reconnect' do
       reconnected = mon.new_cond
 
       nats = NATS::IO::Client.new
-      nats.connect("nats://secret:password@127.0.0.1:4242,nats://secret:password@127.0.0.1:4243", :dont_randomize_servers => true)
+      nats.connect!("nats://secret:password@127.0.0.1:4242,nats://secret:password@127.0.0.1:4243", :dont_randomize_servers => true)
 
       disconnects = 0
       nats.on_disconnect do
@@ -204,7 +204,7 @@ describe 'Client - Cluster reconnect' do
       reconnected = mon.new_cond
 
       nats = NATS::IO::Client.new
-      nats.connect({
+      nats.connect!({
         servers: [@s1.uri, @s2.uri],
         dont_randomize_servers: true
       })
@@ -321,7 +321,7 @@ describe 'Client - Cluster reconnect' do
         end
 
         # Connect to first server only and trigger reconnect
-        nats.connect(:servers => [@s1.uri], :dont_randomize_servers => true, :reconnect => true)
+        nats.connect!(:servers => [@s1.uri], :dont_randomize_servers => true, :reconnect => true)
         expect(nats.connected_server).to eql(@s1.uri)
         @s1.kill_server
         sleep 0.2
@@ -386,7 +386,7 @@ describe 'Client - Cluster reconnect' do
         end
 
         # Connect to first server only and trigger reconnect
-        nats.connect("nats://secret:password@127.0.0.1:4242", :dont_randomize_servers => true, :reconnect => true, :reconnect_time_wait => 0.5)
+        nats.connect!("nats://secret:password@127.0.0.1:4242", :dont_randomize_servers => true, :reconnect => true, :reconnect_time_wait => 0.5)
         expect(nats.connected_server.to_s).to eql(@s1.uri.to_s)
         @s1.kill_server
         sleep 0.1
@@ -443,7 +443,7 @@ describe 'Client - Cluster reconnect' do
       end
 
       # Connect to first server only and trigger reconnect
-      nats.connect({
+      nats.connect!({
         :servers => [@s1.uri],
         :dont_randomize_servers => true,
         :user => 'secret',

--- a/spec/client_cluster_tls_reconnect_spec.rb
+++ b/spec/client_cluster_tls_reconnect_spec.rb
@@ -127,7 +127,7 @@ describe 'Client - Cluster TLS reconnect' do
         ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
         ctx.verify_hostname = true
 
-        nats.connect("tls://server-A.clients.nats-service.localhost:4232", {
+        nats.connect!("tls://server-A.clients.nats-service.localhost:4232", {
                      dont_randomize_servers: true, reconnect: true, tls: {
                        context: ctx
                      }})

--- a/spec/client_delayed_connection_spec.rb
+++ b/spec/client_delayed_connection_spec.rb
@@ -1,0 +1,59 @@
+# Copyright 2016-2018 The NATS Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'monitor'
+
+describe 'Client - Connection' do
+  let(:server) do
+    NatsServerControl.new("nats://127.0.0.1:4522", "/tmp/test-nats.pid", "--cluster nats://127.0.0.1:4248 --cluster_name test-cluster")
+  end
+
+  context "when server isn't available" do
+    it 'should not raise error on connect' do
+      expect do
+        nc = NATS::Client.new
+        nc.connect(servers: [server.uri])
+        nc.close
+      end.to_not raise_error
+    end
+
+    it 'should raise error on connect!' do
+      expect do
+        nc = NATS::Client.new
+        nc.connect!(servers: [server.uri])
+        nc.close
+      end.to raise_error(Errno::ECONNREFUSED)
+    end
+  end
+
+  context "when server is available" do
+    before { server.start_server(true) }
+    after { server.kill_server && sleep(0.1) }
+
+    it "connects to the server on the first command and works" do
+      nc = NATS::Client.new
+      nc.connect(servers: [server.uri])
+
+      nc.subscribe("service") do |msg|
+        msg.respond("pong")
+      end
+
+      resp = nc.request("service", "ping")
+      expect(resp.data).to eq("pong")
+
+      nc.close
+    end
+  end
+end

--- a/spec/client_drain_spec.rb
+++ b/spec/client_drain_spec.rb
@@ -14,8 +14,8 @@ describe 'Client - Drain' do
   end
 
   it 'should gracefully drain a connection' do
-    nc = NATS.connect
-    nc2 = NATS.connect(drain_timeout: 15)
+    nc = NATS.connect!
+    nc2 = NATS.connect!(drain_timeout: 15)
 
     errors = []
     nc.on_error do |e|
@@ -93,7 +93,7 @@ describe 'Client - Drain' do
   end
 
   it 'should report drain timeout error' do
-    nc = NATS.connect(drain_timeout: 0.1)
+    nc = NATS.connect!(drain_timeout: 0.1)
 
     future = Future.new
 

--- a/spec/client_errors_spec.rb
+++ b/spec/client_errors_spec.rb
@@ -27,7 +27,7 @@ describe 'Client - Errors' do
 
   it 'should process errors from server' do
     nats = NATS::IO::Client.new
-    nats.connect(reconnect: false)
+    nats.connect!(reconnect: false)
 
     mon = Monitor.new
     done = mon.new_cond
@@ -71,7 +71,7 @@ describe 'Client - Errors' do
     done = mon.new_cond
 
     nats = NATS::IO::Client.new
-    nats.connect(reconnect: false)
+    nats.connect!(reconnect: false)
 
     errors = []
     nats.on_error do |e|
@@ -108,7 +108,7 @@ describe 'Client - Errors' do
 
   it 'should handle as async errors uncaught exceptions from callbacks' do
     nats = NATS::IO::Client.new
-    nats.connect(reconnect: false)
+    nats.connect!(reconnect: false)
 
     mon = Monitor.new
     done = mon.new_cond
@@ -167,7 +167,7 @@ describe 'Client - Errors' do
 
   it 'should handle subscriptions with slow consumers as async errors when over pending msgs limit' do
     nats = NATS::IO::Client.new
-    nats.connect(reconnect: false)
+    nats.connect!(reconnect: false)
 
     mon = Monitor.new
     done = mon.new_cond
@@ -225,7 +225,7 @@ describe 'Client - Errors' do
 
   it 'should handle subscriptions with slow consumers as async errors when over pending bytes limit' do
     nats = NATS::IO::Client.new
-    nats.connect(reconnect: false)
+    nats.connect!(reconnect: false)
 
     mon = Monitor.new
     done = mon.new_cond
@@ -323,7 +323,7 @@ describe 'Client - Errors' do
       end
 
       expect do
-      nats.connect({
+      nats.connect!({
         :servers => ["nats://127.0.0.1:4555"],
         :max_reconnect_attempts => 1,
         :reconnect_time_wait => 1,
@@ -387,7 +387,7 @@ describe 'Client - Errors' do
       end
 
       expect do
-      nc.connect({
+      nc.connect!({
         :servers => ["nats://127.0.0.1:4556"],
         :reconnect => false,
         :connect_timeout => 1
@@ -443,7 +443,7 @@ describe 'Client - Errors' do
       end
 
       expect do
-      nc.connect({
+      nc.connect!({
         :servers => ["nats://127.0.0.1:4556"],
         :reconnect => false,
         :connect_timeout => 1

--- a/spec/client_fork_spec.rb
+++ b/spec/client_fork_spec.rb
@@ -31,7 +31,7 @@ describe 'Client - Fork detection' do
   end
 
   let(:options) { {} }
-  let!(:nats) { NATS.connect("nats://127.0.0.1:4524", options) }
+  let!(:nats) { NATS.connect!("nats://127.0.0.1:4524", options) }
 
   it 'should be able to publish messages from child process after forking' do
     received = nil

--- a/spec/client_nkeys_connect_spec.rb
+++ b/spec/client_nkeys_connect_spec.rb
@@ -46,7 +46,7 @@ describe 'Client - NATS v2 Auth' do
       nats.on_error do |e|
         errors << e
       end
-      nats.connect(servers: ['nats://127.0.0.1:4722'],
+      nats.connect!(servers: ['nats://127.0.0.1:4722'],
                    reconnect: false,
                    user_credentials: "./spec/configs/nkeys/foo-user.creds")
       nats.subscribe("hello") do |msg|
@@ -86,7 +86,7 @@ describe 'Client - NATS v2 Auth' do
         nats.send(:jwt_cb_for_creds_file, "./spec/configs/nkeys/foo-user.creds").call()
       }
 
-      nats.connect(servers: ['nats://127.0.0.1:4722'],
+      nats.connect!(servers: ['nats://127.0.0.1:4722'],
                    reconnect: false,
                    user_signature_cb: sig_cb,
                    user_jwt_cb: jwt_cb)
@@ -120,7 +120,7 @@ describe 'Client - NATS v2 Auth' do
       end
 
       expect do
-        nats.connect(servers: ['nats://127.0.0.1:4722'],
+        nats.connect!(servers: ['nats://127.0.0.1:4722'],
                      reconnect: false)
       end.to raise_error(NATS::IO::AuthError)
 
@@ -179,7 +179,7 @@ describe 'Client - NATS v2 Auth' do
       nats.on_error do |e|
         errors << e
       end
-      nats.connect(servers: ['nats://127.0.0.1:4723'],
+      nats.connect!(servers: ['nats://127.0.0.1:4723'],
                    reconnect: false,
                    nkeys_seed: "./spec/configs/nkeys/foo-user.nk")
       nats.subscribe("hello") do |msg|
@@ -219,7 +219,7 @@ describe 'Client - NATS v2 Auth' do
         nats.send(:signature_cb_for_nkey_file, "./spec/configs/nkeys/foo-user.nk").call(nonce)
       }
 
-      nats.connect(servers: ['nats://127.0.0.1:4723'],
+      nats.connect!(servers: ['nats://127.0.0.1:4723'],
                    reconnect: false,
                    user_nkey_cb: user_nkey_cb,
                    user_signature_cb: sig_cb)

--- a/spec/client_reconnect_spec.rb
+++ b/spec/client_reconnect_spec.rb
@@ -15,7 +15,7 @@ describe 'Client - Reconnect' do
 
   it 'should process errors from a server and reconnect' do
     nats = NATS::IO::Client.new
-    nats.connect({
+    nats.connect!({
       reconnect: true,
       reconnect_time_wait: 2,
       max_reconnect_attempts: 1
@@ -155,7 +155,7 @@ describe 'Client - Reconnect' do
       mon.synchronize { done.signal }
     end
 
-    nats.connect(:reconnect => false)
+    nats.connect!(:reconnect => false)
 
     nats.subscribe("foo") do |msg|
       msgs << msg
@@ -211,7 +211,7 @@ describe 'Client - Reconnect' do
     end
 
     expect do
-      nats.connect({
+      nats.connect!({
        :servers => ["nats://127.0.0.1:4229"],
        :max_reconnect_attempts => 2,
        :reconnect_time_wait => 1
@@ -255,7 +255,7 @@ describe 'Client - Reconnect' do
       mon.synchronize { done.signal }
     end
 
-    nats.connect({
+    nats.connect!({
      :servers => ["nats://127.0.0.1:4222"],
      :max_reconnect_attempts => 1,
      :reconnect_time_wait => 1
@@ -338,7 +338,7 @@ describe 'Client - Reconnect' do
         mon.synchronize { done.signal }
       end
 
-      nats.connect({
+      nats.connect!({
         :servers => ["nats://127.0.0.1:4222", "nats://127.0.0.1:4444"],
         :max_reconnect_attempts => 1,
         :reconnect_time_wait => 1,
@@ -423,7 +423,7 @@ describe 'Client - Reconnect' do
         mon.synchronize { done.signal }
       end
 
-      nats.connect({
+      nats.connect!({
         :servers => ["nats://127.0.0.1:4445","nats://127.0.0.1:4222"],
         :max_reconnect_attempts => -1,
         :reconnect_time_wait => 2,
@@ -507,7 +507,7 @@ describe 'Client - Reconnect' do
         closes += 1
       end
 
-      nats.connect({
+      nats.connect!({
         :servers => ["nats://127.0.0.1:4446","nats://127.0.0.1:4222"],
         :max_reconnect_attempts => -1,
         :reconnect_time_wait => 2,
@@ -594,7 +594,7 @@ describe 'Client - Reconnect' do
         closes += 1
       end
 
-      nats.connect({
+      nats.connect!({
         :servers => ["nats://127.0.0.1:4447"],
         :max_reconnect_attempts => 1,
         :reconnect_time_wait => 2,

--- a/spec/client_threadsafe_spec.rb
+++ b/spec/client_threadsafe_spec.rb
@@ -36,7 +36,7 @@ describe 'Client - Thread safety' do
     end
 
     def connect!
-      @nats.connect(@options)
+      @nats.connect!(@options)
     end
   end
 
@@ -103,7 +103,7 @@ describe 'Client - Thread safety' do
   end
 
   it 'should allow async subscriptions to process messages in parallel' do
-    nc = NATS.connect(servers: ['nats://0.0.0.0:4222'])
+    nc = NATS.connect!(servers: ['nats://0.0.0.0:4222'])
 
     foo_msgs = []
     nc.subscribe('foo') do |payload|
@@ -153,7 +153,7 @@ describe 'Client - Thread safety' do
   end
 
   it 'should connect once across threads' do
-    nc = NATS.connect(@s.uri)
+    nc = NATS.connect!(@s.uri)
     nc.subscribe(">") { }
     nc.subscribe("help") do |msg, reply|
       nc.publish(reply, "OK!")
@@ -179,7 +179,7 @@ describe 'Client - Thread safety' do
     5.times do
       ts << Thread.new do
         # connect should be idempotent across threads.
-        nc.connect(@s.uri)
+        nc.connect!(@s.uri)
         si = nc.instance_variable_get("@server_info")
         cids << si[:client_id]
         responses << nc.request("help", "hi")
@@ -204,7 +204,7 @@ describe 'Client - Thread safety' do
   major_version, minor_version, _ = Gem.loaded_specs['uri'].version.to_s.split('.').map(&:to_i)
   if major_version >= 0 && minor_version >= 11
     it 'should be able to process messages in a Ractor' do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
 
       messages = []
       nc.subscribe('foo') do |msg|
@@ -212,7 +212,7 @@ describe 'Client - Thread safety' do
       end
 
       r1 = Ractor.new(@s.uri) do |uri|
-        r_nc = NATS.connect(uri)
+        r_nc = NATS.connect!(uri)
 
         r_nc.publish('foo', 'bar')
         r_nc.flush
@@ -224,7 +224,7 @@ describe 'Client - Thread safety' do
       expect(messages.count).to eql(1)
 
       r2 = Ractor.new(@s.uri) do |uri|
-        r_nc = NATS.connect(uri)
+        r_nc = NATS.connect!(uri)
 
         r_messages = []
         r_nc.subscribe('bar') do |payload, reply|

--- a/spec/client_tls_spec.rb
+++ b/spec/client_tls_spec.rb
@@ -62,7 +62,7 @@ describe 'Client - TLS spec' do
       end
 
       expect do
-        nats.connect(:servers => ['nats://127.0.0.1:4444'], :reconnect => false)
+        nats.connect!(:servers => ['nats://127.0.0.1:4444'], :reconnect => false)
       end.to raise_error(NATS::IO::ConnectError)
 
       # Async handler also gets triggered since defined
@@ -94,7 +94,7 @@ describe 'Client - TLS spec' do
         tls_context = OpenSSL::SSL::SSLContext.new
         tls_context.set_params
         tls_context.ca_file = "./spec/configs/certs/ca.pem"
-        nats.connect({
+        nats.connect!({
           servers: ['tls://127.0.0.1:4444'],
           reconnect: false,
           tls: {
@@ -131,7 +131,7 @@ describe 'Client - TLS spec' do
       nats = NATS::IO::Client.new
 
       # Discard error since only want to confirm that TLS is setup due to scheme option.
-      nats.connect('tls://127.0.0.1:4444', reconnect:false) rescue nil
+      nats.connect!('tls://127.0.0.1:4444', reconnect:false) rescue nil
       expect(nats.options[:tls]).to_not be_nil
     end
     
@@ -154,7 +154,7 @@ describe 'Client - TLS spec' do
         tls_context = OpenSSL::SSL::SSLContext.new
         tls_context.ssl_version = :TLSv1
 
-        nats.connect({
+        nats.connect!({
                        servers: ['tls://127.0.0.1:4444'],
                        reconnect: false,
                        tls: {
@@ -220,7 +220,7 @@ describe 'Client - TLS spec' do
         tls_context.ca_file = "./spec/configs/certs/ca.pem"
         tls_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
-        nats.connect({
+        nats.connect!({
           servers: ['tls://127.0.0.1:4555'],
           reconnect: false,
           tls: {
@@ -285,7 +285,7 @@ describe 'Client - TLS spec' do
       expect do
         nats = NATS::IO::Client.new
 
-        nats.connect({
+        nats.connect!({
           servers: ["tls://server-A.clients.nats-service.localhost:#{@tls_verify_host_server_uri.port}"],
           reconnect: false,
           tls: {
@@ -306,7 +306,7 @@ describe 'Client - TLS spec' do
       expect do
         nats = NATS::IO::Client.new
 
-        nats.connect({
+        nats.connect!({
           servers: ["tls://server-A.clients.fake-nats-service.localhost:#{@tls_verify_host_server_uri.port}"],
           reconnect: false,
           tls: {
@@ -368,7 +368,7 @@ describe 'Client - TLS spec' do
       expect do
         nats = NATS::IO::Client.new
 
-        nats.connect({
+        nats.connect!({
           servers: ["tls://server-A.clients.nats-service.localhost:#{@tls_verify_host_bad_server_uri.port}"],
           reconnect: false,
           tls: {
@@ -394,7 +394,7 @@ describe 'Client - TLS spec' do
       expect do
         nats = NATS::IO::Client.new
 
-        nats.connect({
+        nats.connect!({
           servers: ["tls://server-A.clients.nats-service.localhost:#{@tls_verify_host_bad_server_uri.port}"],
           reconnect: false,
           tls: {
@@ -420,7 +420,7 @@ describe 'Client - TLS spec' do
       expect do
         nats = NATS::IO::Client.new
 
-        nats.connect("tls://server-A.clients.nats-service.localhost:#{@tls_verify_host_bad_server_uri.port}", {
+        nats.connect!("tls://server-A.clients.nats-service.localhost:#{@tls_verify_host_bad_server_uri.port}", {
           reconnect: false,
           tls: {
             context: ctx

--- a/spec/client_v2_spec.rb
+++ b/spec/client_v2_spec.rb
@@ -33,7 +33,7 @@ describe 'Client - v2.2 features' do
     done2 = mon.new_cond
 
     nc = NATS::IO::Client.new
-    nc.connect(:servers => [@s.uri])
+    nc.connect!(:servers => [@s.uri])
 
     msgs = []
 
@@ -117,7 +117,7 @@ describe 'Client - v2.2 features' do
 
   it 'should make requests with headers' do
     nc = NATS::IO::Client.new
-    nc.connect(:servers => [@s.uri])
+    nc.connect!(:servers => [@s.uri])
     nc.on_error do |e|
       puts "Error: #{e}"
       puts e.backtrace
@@ -174,7 +174,7 @@ describe 'Client - v2.2 features' do
   end
 
   it 'should raise no responders error by default' do
-    nc = NATS.connect(servers: [@s.uri])
+    nc = NATS.connect!(servers: [@s.uri])
 
     expect do
       resp = nc.request("hi", "timeout", timeout: 1)
@@ -207,7 +207,7 @@ describe 'Client - v2.2 features' do
 
   it 'should not raise no responders error if no responders disabled' do
     nc = NATS::IO::Client.new
-    nc.connect(servers: [@s.uri], no_responders: false)
+    nc.connect!(servers: [@s.uri], no_responders: false)
 
     resp = nil
     expect do
@@ -242,7 +242,7 @@ describe 'Client - v2.2 features' do
 
   it 'should not raise no responders error if no responders disabled' do
     nc = NATS::IO::Client.new
-    nc.connect(servers: [@s.uri], no_responders: false)
+    nc.connect!(servers: [@s.uri], no_responders: false)
 
     resp = nil
     expect do
@@ -264,7 +264,7 @@ describe 'Client - v2.2 features' do
 
   it 'should handle responses with status and description headers' do
     nc = NATS::IO::Client.new
-    nc.connect(servers: [@s.uri], no_responders: true)
+    nc.connect!(servers: [@s.uri], no_responders: true)
 
     # Create sample Stream and pull based consumer from JetStream
     # from which it will be attempted to fetch messages using no_wait.
@@ -313,7 +313,7 @@ describe 'Client - v2.2 features' do
 
   it 'should get a message with Subscription#next_msg' do
     nc = NATS::IO::Client.new
-    nc.connect(:servers => [@s.uri])
+    nc.connect!(:servers => [@s.uri])
 
     sub = nc.subscribe("hello")
     msgs = []
@@ -349,7 +349,7 @@ describe 'Client - v2.2 features' do
 
   it 'should support NATS::Msg#respond' do
     nc = NATS::IO::Client.new
-    nc.connect(:servers => [@s.uri])
+    nc.connect!(:servers => [@s.uri])
     nc.on_error do |e|
       puts "Error: #{e}"
       puts e.backtrace
@@ -383,7 +383,7 @@ describe 'Client - v2.2 features' do
 
   it 'should make responses with headers NATS::Msg#respond_msg' do
     nc = NATS::IO::Client.new
-    nc.connect(:servers => [@s.uri])
+    nc.connect!(:servers => [@s.uri])
     nc.on_error do |e|
       puts "Error: #{e}"
       puts e.backtrace

--- a/spec/js_spec.rb
+++ b/spec/js_spec.rb
@@ -30,7 +30,7 @@ describe 'JetStream' do
     end
 
     it 'should publish messages to a stream' do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
 
       # Create sample Stream and pull based consumer from JetStream
       # from which it will be attempted to fetch messages using no_wait.
@@ -86,7 +86,7 @@ describe 'JetStream' do
     end
 
     before(:each) do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
       stream_req = {
         name: "test",
         subjects: ["test"]
@@ -97,7 +97,7 @@ describe 'JetStream' do
     end
 
     after(:each) do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
       stream_req = {
         name: "test",
         subjects: ["test"]
@@ -107,7 +107,7 @@ describe 'JetStream' do
       nc.close
     end
 
-    let(:nc) { NATS.connect(@s.uri) }
+    let(:nc) { NATS.connect!(@s.uri) }
 
     it "should auto create pull subscription" do
       js = nc.jetstream
@@ -144,7 +144,7 @@ describe 'JetStream' do
     end
 
     it 'should find the pull subscription by subject' do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
       js = nc.jetstream
 
       consumer_req = {
@@ -166,7 +166,7 @@ describe 'JetStream' do
     end
 
     it 'should pull subscribe and fetch messages' do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
       js = nc.jetstream
 
       consumer_req = {
@@ -433,7 +433,7 @@ describe 'JetStream' do
     end
 
     it 'should unsubscribe' do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
       js = nc.jetstream
 
       consumer_req = {
@@ -475,8 +475,8 @@ describe 'JetStream' do
     end
 
     it 'should account pending data' do
-      nc = NATS.connect(@s.uri)
-      nc2 = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
+      nc2 = NATS.connect!(@s.uri)
       js = nc.jetstream
       subject = "limits.test"
 
@@ -517,7 +517,7 @@ describe 'JetStream' do
     end
 
     it 'should create and bind to consumer with name' do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
       js = nc.jetstream
 
       js.add_stream(name: "ctests", subjects: ['a', 'b', 'c.>'])
@@ -648,7 +648,7 @@ describe 'JetStream' do
     end
 
     before(:each) do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
       stream_req = {
         name: "test",
         subjects: ["test"]
@@ -659,7 +659,7 @@ describe 'JetStream' do
     end
 
     after(:each) do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
       stream_req = {
         name: "test",
         subjects: ["test"]
@@ -669,7 +669,7 @@ describe 'JetStream' do
       nc.close
     end
 
-    let(:nc) { NATS.connect(@s.uri) }
+    let(:nc) { NATS.connect!(@s.uri) }
 
     it "should create ephemeral subscription with auto and manual ack" do
       js = nc.jetstream
@@ -857,7 +857,7 @@ describe 'JetStream' do
     end
 
     it 'should produce, consume and ack messages in a stream' do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
 
       # Create stream in the domain.
       subject = "foo"
@@ -947,7 +947,7 @@ describe 'JetStream' do
     end
 
     it 'should bail when stream or consumer does not exist in domain' do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
       js = nc.JetStream(domain: @domain)
 
       # Should try to auto lookup and fail.
@@ -1106,7 +1106,7 @@ describe 'JetStream' do
       FileUtils.remove_entry(@tmpdir)
     end
 
-    let(:nc) { NATS.connect(@s.uri) }
+    let(:nc) { NATS.connect!(@s.uri) }
 
     it "should support jsm.add_stream" do
       stream_config = {
@@ -1320,7 +1320,7 @@ describe 'JetStream' do
     end
 
     it "should support jsm.consumer_info" do
-      nc = NATS.connect(@s.uri)
+      nc = NATS.connect!(@s.uri)
 
       stream_req = {
         name: "quux",

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -15,7 +15,7 @@ describe 'KeyValue' do
   end
 
   it 'should support access to KeyValue stores' do
-    nc = NATS.connect(@s.uri)
+    nc = NATS.connect!(@s.uri)
 
     js = nc.jetstream
     kv = js.create_key_value(bucket: "TEST", history: 5, ttl: 3600)
@@ -62,7 +62,7 @@ describe 'KeyValue' do
   end
 
   it "should report when bucket is not found or invalid" do
-    nc = NATS.connect(@s.uri)
+    nc = NATS.connect!(@s.uri)
 
     js = nc.jetstream
     expect do
@@ -85,7 +85,7 @@ describe 'KeyValue' do
   end
 
   it 'should support access to KeyValue stores from multiple instances' do
-    nc = NATS.connect(@s.uri)
+    nc = NATS.connect!(@s.uri)
 
     js = nc.jetstream
     kv = js.create_key_value(bucket: "TEST2")
@@ -93,7 +93,7 @@ describe 'KeyValue' do
       kv.put(l, l*10)
     end
 
-    nc2 = NATS.connect(@s.uri)
+    nc2 = NATS.connect!(@s.uri)
     js2 = nc2.jetstream
     kv2 = js2.key_value("TEST2")
     a = kv2.get("a")
@@ -104,7 +104,7 @@ describe 'KeyValue' do
   end
 
   it 'should support get by revision' do
-    nc = NATS.connect(@s.uri)
+    nc = NATS.connect!(@s.uri)
     js = nc.jetstream
     kv = js.create_key_value(bucket: "TEST", history: 5, ttl: 3600, description: "Basic KV")
 
@@ -285,7 +285,7 @@ describe 'KeyValue' do
   end
 
   it 'should support direct get' do
-    nc = NATS.connect(@s.uri)
+    nc = NATS.connect!(@s.uri)
     js = nc.jetstream
     kv = js.create_key_value(
            bucket: "TESTDIRECT",
@@ -349,7 +349,7 @@ describe 'KeyValue' do
   end
 
   it 'should support republish' do
-    nc = NATS.connect(@s.uri)
+    nc = NATS.connect!(@s.uri)
     js = nc.jetstream
     kv = js.create_key_value(
            bucket: "TESTRP",


### PR DESCRIPTION
Change behavior of `NATS.connect(uri, opts)` to not connect until first usage, introduce `NATS.connect!(uri, opts)` to allow use old behavior.